### PR TITLE
Add opacity:0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 npm-debug.log.*
 /temp/
 .DS_store
+.history
+.vscode

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,9 @@ export function isVisible (element) {
     if (getStyle(element, 'display') === 'none') {
       return false;
     }
+    if (getStyle(element, 'opacity').toString() === '0') {
+      return false;
+    }
     element = element.parentNode;
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,6 +40,11 @@ describe('isVisible', function() {
     expect(isVisible(elm)).toEqual(false);
   });
 
+  it('should say element with 0 opacity is not visible', function() {
+    elm.style.opacity = 0;
+    expect(isVisible(elm)).toEqual(false);
+  });
+
   it('should say visible element in hidden parent is visible', function () {
     const child = elm.appendChild(document.createElement('div'));
     elm.style.visibility = 'hidden';
@@ -64,6 +69,12 @@ describe('isVisible', function() {
   it('should say child element of hidden element is not visible', function() {
     const sub_elm = elm.appendChild(document.createElement('div'));
     elm.style.display = 'none';
+    expect(isVisible(sub_elm)).toEqual(false);
+  });
+
+  it('should say child element of an element with 0 opacity is not visible', function() {
+    const sub_elm = elm.appendChild(document.createElement('div'));
+    elm.style.opacity = 0;
     expect(isVisible(sub_elm)).toEqual(false);
   });
 


### PR DESCRIPTION
This PR adds support for checking items that have an opacity of 0 (including parents).

I couldn't find any notes/docs in this repo relating to opacity. 

Thanks for the great library!